### PR TITLE
Fix command to serve site

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ jekyll build
 #### Serve
 
 ```
-jsekyll serve
+jekyll serve
 ```
 
 #### Deploy


### PR DESCRIPTION
"jekyll" misspelling? I am not familiar enough to know if "jsekyll" is another binary. If so, please reject this PR.
