### PR TITLE
chore: bump deps to avoid event-stream & pin hugo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ else
 endif
 
 build: clean install lint css js minify
-	$(PREPEND)hugo && \
+	$(PREPEND)$(NPMBIN)/hugo && \
 	echo "" && \
 	echo "Site built out to ./public dir"
 
@@ -37,7 +37,7 @@ help:
 	@echo '   DEBUG=true make [command] for increased verbosity                                                      '
 
 serve: install lint js css minify
-	$(PREPEND)hugo server
+	$(PREPEND)$(NPMBIN)/hugo server
 
 node_modules:
 	$(PREPEND)$(NPM) i $(APPEND)
@@ -66,7 +66,7 @@ minify-img: install
 dev: install css js
 	$(PREPEND)( \
 		$(NPMBIN)/nodemon --watch css --exec "$(NPMBIN)/lessc --clean-css --autoprefix less/main.less static/css/main.css" & \
-		hugo server -w \
+		$(NPMBIN)/hugo server -w \
 	)
 
 deploy:

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "homepage": "https://github.com/tableflip/ipld.io#readme",
   "devDependencies": {
     "dnslink-deploy": "^1.0.7",
+    "hugo-bin": "0.18.1",
     "imagemin-cli": "^3.0.0",
     "imagemin-jpegtran": "^5.0.2",
     "imagemin-optipng": "^5.2.1",
@@ -28,7 +29,7 @@
     "less": "^2.7.2",
     "less-plugin-autoprefix": "^1.5.1",
     "less-plugin-clean-css": "^1.5.1",
-    "nodemon": "^1.11.0",
+    "nodemon": "^1.18.7",
     "standard": "^10.0.2",
     "surge": "^0.19.0",
     "tachyons": "^4.7.4",


### PR DESCRIPTION
nodemon was potentially affected by the event-stream issue
https://github.com/dominictarr/event-stream/issues/116

This PR bumps those deps to the latest release that avoid it.

To make the site build reliably, it adds hugo as a dev dep and
pins it to vesion v0.31.1 that is known to work with the current
ipld.io website src.

License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>